### PR TITLE
add support for creating custom web socket connections

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,11 +7,20 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Launch Program",
+      "name": "Run Tests",
       "skipFiles": [
         "<node_internals>/**"
       ],
       "program": "${workspaceFolder}/node_modules/.bin/_mocha",
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Run Server",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "program": "${workspaceFolder}/bin/server",
     }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
 const { IncomingMessage, ServerResponse } = require('http');
 const { Transform } = require('stream');
-const { Socket } = require('net');
 const WebSocket = require('ws');
 const protobuf = require('protobufjs');
 
 const root = protobuf.loadSync(__dirname + '/schemas/proxy.proto');
 const RequestMessage = root.lookupType('socketproxy.Request');
-const ResponseMessage = root.lookupType('socketproxy.ResponseChunk');
-const ResponseType = ResponseMessage.lookup('MessageType').values;
+const ResponseChunk = root.lookupType('socketproxy.ResponseChunk');
+const WebSocketMessage = root.lookupType('socketproxy.WebSocketMessage');
+const ProxyMessage = root.lookupType('socketproxy.ProxyMessage');
+const ResponseType = ResponseChunk.lookup('MessageType').values;
 
 class SocketProxy {
   constructor(opts) {
@@ -36,23 +37,34 @@ class SocketProxy {
     }
   }
 
+  _sendProxyMessage(data, cb) {
+    const message = ProxyMessage.fromObject(data);
+    const payload = ProxyMessage.encode(message).finish();
+    this.ws.send(payload, cb);
+  }
+
   finishResponse(uuid) {
-    const responseMessage = ResponseMessage.create({
+    const responseChunk = ResponseChunk.create({
       uuid,
       type: ResponseType.FINISH
     });
-    const payload = ResponseMessage.encode(responseMessage).finish();
-    this.ws.send(payload);
+    this._sendProxyMessage({ responseChunk });
+  }
+
+  send(message) {
+    const data = JSON.stringify(message);
+    const webSocketMessage = WebSocketMessage.fromObject({ data });
+    this._sendProxyMessage({ webSocketMessage });
   }
 
   ping() {
     return new Promise((resolve, reject) => {
-      const responseMessage = ResponseMessage.create({
+      const responseMessage = ResponseChunk.create({
         type: ResponseType.PING
       });
-      const payload = ResponseMessage.encode(responseMessage).finish();
+      const responseChunk = ResponseChunk.encode(responseMessage).finish();
 
-      this.ws.send(payload, (err) => {
+      this._sendProxyMessage({ responseChunk }, (err) => {
         if(err) {
           reject(err);
         } else {
@@ -88,12 +100,15 @@ class SocketProxy {
     });
   }
 
-  handleStatus(data, resolve) {
+  handleStatus(data) {
     const message = RequestMessage.decode(data);
     if(!message.connectionInfo) { return {}; }
     this.savedUri = message.connectionInfo.uri;
 
-    return { uri: this.savedUri };
+    const connectionId = message.connectionInfo.connectionId;
+    this.connectionId = connectionId;
+
+    return { uri: this.savedUri, connectionId };
   }
 
   close() {
@@ -115,13 +130,15 @@ class FakeSocket extends Transform {
       chunk = Buffer.from(chunk);
     }
 
-    const responseMessage = ResponseMessage.create({
+    const responseChunk = ResponseChunk.create({
       uuid: this.uuid,
       type: ResponseType.CHUNK,
       encoding,
       data: chunk
     });
-    const payload = ResponseMessage.encode(responseMessage).finish();
+
+    const message = ProxyMessage.fromObject({ responseChunk });
+    const payload = ProxyMessage.encode(message).finish();
     this.ws.send(payload);
 
     return true;

--- a/index.js
+++ b/index.js
@@ -51,8 +51,12 @@ class SocketProxy {
     this._sendProxyMessage({ responseChunk });
   }
 
+  sendJSON(message) {
+    this.send(JSON.stringify(message));
+  }
+
   send(message) {
-    const data = JSON.stringify(message);
+    const data = new TextEncoder("utf-8").encode(message);
     const webSocketMessage = WebSocketMessage.fromObject({ data });
     this._sendProxyMessage({ webSocketMessage });
   }

--- a/schemas/proxy.proto
+++ b/schemas/proxy.proto
@@ -17,7 +17,7 @@ message ConnectionInfo {
 
 message WebSocketMessage {
   string connectionId = 1;
-  string data = 2; // JSON structure needed here.
+  bytes data = 2;
 }
 
 message HttpRequest {

--- a/schemas/proxy.proto
+++ b/schemas/proxy.proto
@@ -12,6 +12,12 @@ message Request {
 
 message ConnectionInfo {
   string uri = 1;
+  string connectionId = 2;
+}
+
+message WebSocketMessage {
+  string connectionId = 1;
+  string data = 2; // JSON structure needed here.
 }
 
 message HttpRequest {
@@ -43,4 +49,11 @@ message ResponseChunk {
 
   string encoding = 3;
   bytes data = 4;
+}
+
+message ProxyMessage {
+  oneof inner_message {
+    ResponseChunk responseChunk = 1;
+    WebSocketMessage webSocketMessage = 2;
+  }
 }

--- a/src/custom-connections.js
+++ b/src/custom-connections.js
@@ -1,0 +1,40 @@
+class CustomConnections {
+  _collection = new Map();
+
+  add(connectionId, socket) {
+    const set = this.setFor(connectionId);
+    set.add(socket);
+  }
+
+  *entriesFor(connectionId) {
+    const set = this.setFor(connectionId);
+
+    for (const socket of set) {
+      yield socket;
+    }
+  }
+
+  delete(connectionId, socket = null) {
+    const set = this.setFor(connectionId);
+
+    if (socket) {
+      set.delete(socket);
+    }
+
+    if (!socket || set.size === 0) {
+      this._collection.delete(connectionId);
+    }
+  }
+
+  setFor(connectionId) {
+    if (!this._collection.has(connectionId)) {
+      const set = new Set();
+      this._collection.set(connectionId, set);
+      return set;
+    }
+
+    return this._collection.get(connectionId);
+  }
+}
+
+module.exports = CustomConnections;

--- a/test/test.js
+++ b/test/test.js
@@ -100,7 +100,7 @@ describe('SocketProxy integration', function() {
 
       const client = new WebSocket(`ws://localhost:8080?connectionId=${connectionId}`);
 
-      client.on('open', () => this.proxy.send({ message: 'HELLO WORLD' }));
+      client.on('open', () => this.proxy.sendJSON({ message: 'HELLO WORLD' }));
 
       client.on('message', data => {
         expect(JSON.parse(data)).to.deep.eq({ message: 'HELLO WORLD' });


### PR DESCRIPTION
Signed-off-by: Spencer Price <spencer516@gmail.com>

This PR adds the ability for the SocketProxy to _also_ support regular "custom" WebSocket connections if the client connects to the services at the `/ws` path and provides the `connectionId` parameter. (I call it "custom" because this service is _already_ operating over WebSockets for simulating a web server, so needed some way to distinguish 🤷 )

If the client looking to connect is the same one that is using the `SocketProxy` class, then this provides a method for creating a new connection with: 

```js
proxy.connectNewSocket()
```

Otherwise, other clients can connect with the URL based on the connection ID: 

```js
const client = new WebSocket(`ws://tunnel.movabledev.com/ws?connectionId=${ID}`);
```

[🏠 [ch38366]](https://app.clubhouse.io/movableink/story/38366/support-proxying-studio-to-local-development)
